### PR TITLE
Ups api

### DIFF
--- a/propertyRating/Gemfile
+++ b/propertyRating/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-
+# gem to wrap the UPS API - jjw
+gem 'address_validator', github: 'youbeauty/address-validator'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.1'
 # Use sqlite3 as the database for Active Record

--- a/propertyRating/Gemfile.lock
+++ b/propertyRating/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: git://github.com/youbeauty/address-validator.git
+  revision: 0394dc5dff28b4969ff4d2d6ecba37909e021236
+  specs:
+    address_validator (0.1.0)
+      builder (>= 3.0.4)
+      httparty (>= 0.11.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -56,6 +64,9 @@ GEM
     globalid (0.3.4)
       activesupport (>= 4.1.0)
     hike (1.2.3)
+    httparty (0.13.3)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     jbuilder (2.2.12)
       activesupport (>= 3.0.0, < 5)
@@ -73,6 +84,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.5.1)
     multi_json (1.11.0)
+    multi_xml (0.5.5)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     rack (1.6.0)
@@ -145,6 +157,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  address_validator!
   byebug
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)

--- a/propertyRating/app/assets/stylesheets/properties.scss
+++ b/propertyRating/app/assets/stylesheets/properties.scss
@@ -35,3 +35,7 @@ th{
   background-color: #add8e6;
   color: #111517;
 }
+
+.notice {
+  color:red;
+}

--- a/propertyRating/app/views/properties/new.html.erb
+++ b/propertyRating/app/views/properties/new.html.erb
@@ -1,6 +1,7 @@
 <header>
   <h1>New Property</h1>
 </header>
+<h4 class="notice"><%=flash[:notice]%></h4>
 
 <%= render 'form' %>
 


### PR DESCRIPTION
Hey guys. Here's my code. 
The UPS Address Validation is not as robust as I expected. But it does work!

It will return 'invalid' for obviously invalid addresses (like numbers with no street name) and it sometimes kicks out streets if they don't exist in a particular city, but not always. It doesn't know house numbers, but it knows blocks. So I live on the 4500 block of Puttor Drive in Eau Claire. It will accept 4514 (which doesn't exist) as valid. But if I try 1000, it comes back as ambiguous. It knows the street exists, but it knows the numbers don't go down that low. 

As far as flow, right now when you add something incorrectly it displays the error and clears the fields. This is not ideal. I would like to at least display the invalid address in the error message. Or I would prefer if we redirect to a new page and give the user an option of retrying or not. Also, the API has the ability to return possible matches for ambiguous addresses, which we could try to include, but the wrapper I found does not support that. 